### PR TITLE
Fixes invalid sigma/epsilon values from triggering preview

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>PHANTAST</groupId>
 	<artifactId>PHANTAST_</artifactId>
-	<version>0.2</version>
+	<version>0.3</version>
 
 	<name>Phase Contrast Segmentation Toolbox (PHANTAST)</name>
 	<description>The phae contrast segmentation toolbox (PHANTAST) enables high performance segmentation of phase contrast microscopy images</description>

--- a/src/main/java/PHANTAST_.java
+++ b/src/main/java/PHANTAST_.java
@@ -234,7 +234,8 @@ public class PHANTAST_<T extends RealType<T> & NativeType<T>> implements Extende
 	    	slider = (int) gd.getNextNumber();
 	    }
 		previewing        = gd.getPreviewCheckbox().getState();       
-	    
+		   
+		if( sigma == 0.0 || epsilon == 0.0 || Double.isNaN(sigma) ||  Double.isNaN(epsilon) ) return false;
 	    return true;
     }
 


### PR DESCRIPTION
Just adding a sanity check for the epsilon and sigma values, which I had not noticed last time. 

Useful when a user needs to change the values, and accidentally enters a character or sets it temporarily to 0. 