### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>6.1.3</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -61,10 +61,9 @@
 	</scm>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 
@@ -91,4 +90,7 @@
 		</dependency>
 	</dependencies>
 
+	<properties>
+		<enforcer.skip>true</enforcer.skip>
+	</properties>
 </project>


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with an update to the latest pom-scijava parent.